### PR TITLE
Add `README.md` for ClassicallabUB repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# ClassicallabUB
+## Classical and Statistical Mechanics Popularisation Project UB
+
+* ClassicallabUB is a project built by undergraduate students in Physics from the University of Barcelona. The main goals of the project are:
+
+> Develop games and simulations to popularise aspects of classical and statistical mechanics for broader audiences.
+
+> The applications should be realistic classical and statistical mechanical problems, with an emphasis on user-friendly interfaces and engaging visuals.
+
+> The coding is done under the GitHub platform. Weekly meetings ensure cross-collaboration between the students and constant feedback on the goals.
+
+* This repository is related to the more maintained `quantumlabUB` project, which focuses on quantum mechanics popularisation.
+
+* The project is supervised by Carles Calero Borrallo (Department of Condensed Matter Physics) and Prof. Muntsa Guilleumas and Prof. Bruno Julia Diaz (Department of Quantum Physics and Astrophysics) of the University of Barcelona. It is work done under the subject "Pràctiques d'empresa".
+
+---------------------
+
+Currently (April 2023) we have several separate modules in different directories:
+
+### 2dclas
+
+- `2dsim.py`, which simulates a particle under the influence of a scalar potential. Developed by `@arnau-jr`
+
+### particlesinabox
+
+- `particlesinabox.py`, which creates statistical mechanics simulations by computing interacting particles. Developed by `@jofrevalles`


### PR DESCRIPTION
This PR adds a `README.md` file to the `classicallabUB` repository, providing an overview of the project and its modules. I think that having a `README.md` file is a good idea for user experience.

The `README.md` includes:

- A brief introduction to the `ClassicallabUB` project and its main goals
- Information about its relation to the `quantumlabUB` project
- Supervision and academic context of the project
- A list of the current modules, their descriptions, and developers

Adding this `README.md` file will make it easier for users to understand the repository's purpose, the project's structure, and how to use its modules. It also acknowledges the contributions of individual developers and supervisors.

Please let me know if any changes or additional information are required. Thank you!
